### PR TITLE
Fix cycle detection and better node updating

### DIFF
--- a/Assets/Code/Bon/Node.cs
+++ b/Assets/Code/Bon/Node.cs
@@ -16,7 +16,7 @@ namespace Assets.Code.Bon
 		[NonSerialized] private Graph _parent;
 
 		[NonSerialized] public Rect WindowRect;
-		[NonSerialized] public bool VisitFlag = false;
+		[NonSerialized] public int VisitCount = 0;
 		[NonSerialized] public Rect ContentRect;
 		[NonSerialized] public static int LastFocusedNodeId;
 		[NonSerialized] public bool Resizable = true;
@@ -189,6 +189,27 @@ namespace Assets.Code.Bon
 			foreach (var socket in Sockets)
 			{
 				if (!socket.IsConnected() && socket.IsInput()) return false;
+			}
+			return true;
+		}
+
+		/// <summary> Returns the total number of edges connected into this node.</summary>
+		public int GetNumConnectedInputEdges() {
+			int count = 0;
+			foreach (var socket in Sockets) 
+			{
+				if (socket.IsInput () && socket.IsConnected ()) 
+				{
+					count++;
+				}
+			}
+			return count;
+		}
+
+		/// <summary> Returns true this node has no input edges.</summary>
+		public bool IsRootNode() {
+			foreach (var socket in Sockets) {
+				if (socket.IsInput() && socket.IsConnected()) return false;
 			}
 			return true;
 		}

--- a/Assets/Code/Bon/StandardGraphController.cs
+++ b/Assets/Code/Bon/StandardGraphController.cs
@@ -49,7 +49,7 @@ namespace Assets.Code.Bon
 		public void OnLink(Graph graph, Edge edge)
 		{
 			Log.Info("OnLink: Node " + edge.Output.Parent.Id + " with Node " + edge.Input.Parent.Id);
-			graph.UpdateNodes();
+			graph.UpdateNodeAndDependents(edge.Output.Parent);
 		}
 
 		public void OnUnLink(Graph graph, AbstractSocket s01, AbstractSocket s02)
@@ -60,7 +60,8 @@ namespace Assets.Code.Bon
 		public void OnUnLinked(Graph graph, AbstractSocket s01, AbstractSocket s02)
 		{
 			Log.Info("OnUnLinked: Socket " + s02 + " and Socket " + s02);
-			graph.UpdateNodes();
+			var input = s01.IsInput () ? s01 : s02;
+			graph.UpdateNodeAndDependents(input.Parent);
 		}
 
 		public void OnNodeAdded(Graph graph, Node node)
@@ -76,7 +77,7 @@ namespace Assets.Code.Bon
 		public void OnNodeChanged(Graph graph, Node node)
 		{
 			Log.Info("OnNodeChanged: Node " + node.GetType() + " with id " + node.Id);
-			graph.ForceUpdateNodes();
+			graph.ForceUpdateNodeAndDependents (node);
 		}
 
 		public void OnFocusNode(Graph graph, Node node)


### PR DESCRIPTION
Hi thanks for adding multiple edge support. I've fixed a problem with cycle detection. Because the graph is now a directed graph rather than a tree, a slightly more complex algorithm is needed.

For example in this graph there is no cycle, even though node (1) is visited twice.
![](http://i.imgur.com/tEkM5xy.png)

The algorithm basically walks the graph from the root nodes and increases the VisitCount every time it hits a node, but it only continues to a nodes dependents once the VisitCount is equal to the number of inward incident edges of that node. If there is a cycle then the algorithm cannot continue and therefore we can check is all of the nodes' VisitCount == number of inward incident edges.

The algorithm is also similar to how to avoid glitches. A glitch happens in the above example if we naively update each node and the node's dependents. (0) updates (1) and (2). (2) will update (1) and therefore (1) was updated once with incorrect data and then again with the correct data.

So I've added methods for `UpdateNodeAndDependents(Node node)` which is called when you change/link/unlink a node. Should avoid updating nodes which don't need to change :)

I've tried to follow your code style but let me know if there is anything you'd like me to change regarding the code.